### PR TITLE
Update metadata title->name per provider spec.

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -36,7 +36,7 @@ Model.prototype.getData = function (req, callback) {
 
     // Optional: Service metadata and geometry type
     // geojson.metadata = {
-    //   title: 'Koop Sample Provider',
+    //   name: 'Koop Sample Provider',
     //   description: `Generated from ${url}`,
     //   geometryType: 'Polygon' // Default is automatic detection in Koop
     // }


### PR DESCRIPTION
Update example service metadata from 'title' to 'name'.  'Name' is the correct field specified in the Koop provider specification and 'title' will show up as 'not set' when adding as ArcGIS Online layer to web map.